### PR TITLE
Implementation of intern table for file_data keys

### DIFF
--- a/coverage/ctracer/module.c
+++ b/coverage/ctracer/module.c
@@ -44,10 +44,24 @@ PyInit_tracer(void)
         return NULL;
     }
 
+    InternTableType.tp_new = PyType_GenericNew;
+    if (PyType_Ready(&InternTableType) < 0) {
+        Py_DECREF(mod);
+        return NULL;
+    }
+
     Py_INCREF(&CTracerType);
     if (PyModule_AddObject(mod, "CTracer", (PyObject *)&CTracerType) < 0) {
         Py_DECREF(mod);
         Py_DECREF(&CTracerType);
+        return NULL;
+    }
+
+    Py_INCREF(&InternTableType);
+    if (PyModule_AddObject(mod, "InternTable", (PyObject *)&InternTableType) < 0) {
+        Py_DECREF(mod);
+        Py_DECREF(&InternTableType);
+        Py_DECREF(&InternTableType);
         return NULL;
     }
 

--- a/coverage/ctracer/module.c
+++ b/coverage/ctracer/module.c
@@ -44,12 +44,6 @@ PyInit_tracer(void)
         return NULL;
     }
 
-    InternTableType.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&InternTableType) < 0) {
-        Py_DECREF(mod);
-        return NULL;
-    }
-
     Py_INCREF(&CTracerType);
     if (PyModule_AddObject(mod, "CTracer", (PyObject *)&CTracerType) < 0) {
         Py_DECREF(mod);
@@ -57,10 +51,16 @@ PyInit_tracer(void)
         return NULL;
     }
 
+    /* Initialize InternTable */
+    InternTableType.tp_new = PyType_GenericNew;
+    if (PyType_Ready(&InternTableType) < 0) {
+        Py_DECREF(mod);
+        return NULL;
+    }
+
     Py_INCREF(&InternTableType);
     if (PyModule_AddObject(mod, "InternTable", (PyObject *)&InternTableType) < 0) {
         Py_DECREF(mod);
-        Py_DECREF(&InternTableType);
         Py_DECREF(&InternTableType);
         return NULL;
     }
@@ -70,6 +70,7 @@ PyInit_tracer(void)
     if (PyType_Ready(&CFileDispositionType) < 0) {
         Py_DECREF(mod);
         Py_DECREF(&CTracerType);
+        Py_DECREF(&InternTableType);
         return NULL;
     }
 
@@ -77,6 +78,7 @@ PyInit_tracer(void)
     if (PyModule_AddObject(mod, "CFileDisposition", (PyObject *)&CFileDispositionType) < 0) {
         Py_DECREF(mod);
         Py_DECREF(&CTracerType);
+        Py_DECREF(&InternTableType);
         Py_DECREF(&CFileDispositionType);
         return NULL;
     }
@@ -108,6 +110,15 @@ inittracer(void)
 
     Py_INCREF(&CTracerType);
     PyModule_AddObject(mod, "CTracer", (PyObject *)&CTracerType);
+
+    /* Initialize InternTable */
+    InternTableType.tp_new = PyType_GenericNew;
+    if (PyType_Ready(&InternTableType) < 0) {
+        return;
+    }
+
+    Py_INCREF(&InternTableType);
+    PyModule_AddObject(mod, "InternTable", (PyObject *)&InternTableType);
 
     /* Initialize CFileDisposition */
     CFileDispositionType.tp_new = PyType_GenericNew;

--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -8,6 +8,8 @@
 #include "filedisp.h"
 #include "tracer.h"
 
+#include <assert.h>
+
 /* Python C API helpers. */
 
 static int
@@ -74,6 +76,13 @@ CTracer_init(CTracer *self, PyObject *args_unused, PyObject *kwds_unused)
     self->context = Py_None;
     Py_INCREF(self->context);
 
+    self->intern_table.capacity = 32;
+    self->intern_table.max_fill = 21;
+    self->intern_table.current_fill = 0;
+    self->intern_table.zero_value = NULL;
+    self->intern_table.entries = calloc(
+        self->intern_table.capacity, sizeof(InternEntry));
+
     ret = RET_OK;
     goto ok;
 
@@ -88,6 +97,7 @@ static void
 CTracer_dealloc(CTracer *self)
 {
     int i;
+    size_t j;
 
     if (self->started) {
         PyEval_SetTrace(NULL, NULL);
@@ -115,6 +125,11 @@ CTracer_dealloc(CTracer *self)
     Py_XDECREF(self->data_stack_index);
 
     Py_TYPE(self)->tp_free((PyObject*)self);
+    Py_XDECREF(self->intern_table.zero_value);
+    for(j = 0; j < self->intern_table.capacity; j++){
+        Py_XDECREF(self->intern_table.entries[j].value);
+    }
+    free(self->intern_table.entries);
 }
 
 #if TRACE_LOG
@@ -167,17 +182,149 @@ showlog(int depth, int lineno, PyObject * filename, const char * msg)
 static const char * what_sym[] = {"CALL", "EXC ", "LINE", "RET "};
 #endif
 
+
+// From http://www.cris.com/~Ttwang/tech/inthash.htm via
+// https://chromium.googlesource.com/chromium/blink/+/master/Source/wtf/HashFunctions.h
+static uint64_t hash64(uint64_t key){
+    key += ~(key << 32);
+    key ^= (key >> 22);
+    key += ~(key << 13);
+    key ^= (key >> 8);
+    key += (key << 3);
+    key ^= (key >> 15);
+    key += ~(key << 27);
+    key ^= (key >> 31);
+    return key;
+}
+
+/*
+    Needs to be predeclared because this function is mutally recursive with
+    InternTable_lookup
+*/
+static PyObject **
+InternTable_lookup(InternTable *table, uint64_t key);
+
+/*
+ Core implementation of the InternTable hash table.
+
+ This attempts to look up a key at a particular point in the table. If the key
+ is present there, it returns the corresponding value pointer. If another key
+ is present there, it returns NULL. If no key is present there, it inserts the
+ key (mapping to NULL) at that point, possible grows the hash table, and
+ returns a value pointer for the key.
+
+*/
+static inline PyObject ** InternEntry_matches(
+    InternTable *table, size_t location, uint64_t key
+){
+    size_t index = location & (table->capacity - 1);
+    InternEntry *entry = table->entries + index;
+    size_t i;
+    if(!entry->key){
+        entry->key = key;
+        table->current_fill += 1;
+        if(table->current_fill > table->max_fill){
+            size_t old_capacity = table->capacity;
+            size_t old_fill = table->current_fill;
+            InternEntry *old_entries = table->entries;
+            table->capacity *= 2;
+            table->max_fill *= 2;
+            table->current_fill = 0;
+            table->entries = calloc(table->capacity, sizeof(InternEntry));
+
+            /* Copy the existing entries to the new table. We start by copying
+               entries that can be successfully looked up without hashing
+               because they're at the right point in the table, then we copy
+               the rest. This ensures that table lookups should get faster as
+               we grow, because the number of keys we can look up without
+               hashing cannot decrease and will often increase. */
+
+            for(i = 0; i < old_capacity; i++){
+                InternEntry *prev = old_entries + i;
+                if((prev->key & (old_capacity - 1)) == i){
+                    *InternTable_lookup(table, prev->key) = prev->value;
+                }
+            }
+            for(i = 0; i < old_capacity; i++){
+                InternEntry *prev = old_entries + i;
+                if((prev->key & (old_capacity - 1)) != i){
+                    *InternTable_lookup(table, prev->key) = prev->value;
+                }
+            }
+            free(old_entries);
+            assert(table->current_fill == old_fill);
+
+            /* The shape of the table has changed and the caller doesn't know
+               about that, so we just recurse and look up the key in the new
+               shape. This recursion is always sharply bounded, because we've
+               ensured that the key is in the table already so this call cannot
+               cause the table size to grow further. */
+            return InternTable_lookup(table, key);
+        } else {
+            return &entry->value;
+        }
+    }
+    if(entry->key == key){
+        return &entry->value;
+    }
+    return NULL;
+}
+
+/*
+Look up a key in the table, returning a pointer to a *PyObject where the
+corresponding object will be stored. This will always return non-null, but for
+a freshly created key it will be a pointer to null. The caller should then
+populate the cell with the newly created object.
+*/
+static PyObject **
+InternTable_lookup(InternTable *table, uint64_t key){
+    size_t i;
+
+    if(key == 0){
+        return &(table->zero_value);
+    }
+    PyObject ** initial_attempt = InternEntry_matches(table, key, key);
+    if(initial_attempt != NULL){
+        return initial_attempt;
+    }
+    size_t probe = hash64(key) & (table->capacity - 1);
+    for(i = 0; i < table->capacity; i++){
+        PyObject ** attempt = InternEntry_matches(table, probe + i, key);
+        if(attempt != NULL) return attempt;
+    }
+    assert(0);
+    return NULL;
+}
+
 /* Record a pair of integers in self->pcur_entry->file_data. */
 static int
 CTracer_record_pair(CTracer *self, int l1, int l2)
 {
     int ret = RET_ERROR;
 
-    PyObject * t = NULL;
+    /*
+    We combine the two int values into a uint64_t in a slightly odd way: Rather
+    than just concatenate them, we xor them together for the low bits. The
+    reason for this is that it allows us to trigger our no-hash lookup in the
+    table more often, because it ensures a reasonable range of diversity in the
+    low bits. We can recreate the original key as u1 = key >> 32,
+    u2 = ((uint32_t)u1) ^ ((uint32_t)key), so this still maps the tuple to a
+    unique key.
+    */
+    uint64_t u1 = (uint32_t)l1;
+    uint64_t u2 = (uint32_t)l2;
+    uint64_t key = (u1 << 32) | (u1 ^ u2);
 
-    t = Py_BuildValue("(ii)", l1, l2);
-    if (t == NULL) {
-        goto error;
+    PyObject ** container = InternTable_lookup(
+        &self->intern_table, key);
+
+    PyObject *t = *container;
+    if(t == NULL){
+        t = Py_BuildValue("(ii)", l1, l2);
+        if (t == NULL) {
+            goto error;
+        }
+        *container = t;
     }
 
     if (PyDict_SetItem(self->pcur_entry->file_data, t, Py_None) < 0) {
@@ -185,11 +332,29 @@ CTracer_record_pair(CTracer *self, int l1, int l2)
     }
 
     ret = RET_OK;
-
 error:
-    Py_XDECREF(t);
-
     return ret;
+}
+
+
+/* Record a single integer in self->pcur_entry->file_data. */
+static int
+CTracer_record_int(CTracer *self, int lineno_from){
+
+    PyObject ** container = InternTable_lookup(
+        &self->intern_table, (uint64_t)lineno_from);
+
+    PyObject * this_line = *container;
+    if (this_line == NULL) {
+        this_line = MyInt_FromInt(lineno_from);
+        *container = this_line;
+    }
+
+    if (this_line == NULL) {
+        return RET_ERROR;
+    }
+
+    return PyDict_SetItem(self->pcur_entry->file_data, this_line, Py_None);
 }
 
 /* Set self->pdata_stack to the proper data_stack to use. */
@@ -708,14 +873,7 @@ CTracer_handle_line(CTracer *self, PyFrameObject *frame)
                         }
                     }
                     else {
-                        /* Tracing lines: key is simply this_line. */
-                        PyObject * this_line = MyInt_FromInt(lineno_from);
-                        if (this_line == NULL) {
-                            goto error;
-                        }
-
-                        ret2 = PyDict_SetItem(self->pcur_entry->file_data, this_line, Py_None);
-                        Py_DECREF(this_line);
+                        ret2 = CTracer_record_int(self, lineno_from);
                         if (ret2 < 0) {
                             goto error;
                         }

--- a/coverage/ctracer/tracer.h
+++ b/coverage/ctracer/tracer.h
@@ -8,8 +8,49 @@
 #include "structmember.h"
 #include "frameobject.h"
 #include "opcode.h"
+#include <stdint.h>
 
 #include "datastack.h"
+
+
+/*
+We use normal Python objects as keys for writing into the file_data
+dictionaries.
+
+This ends up creating the same duplicate objects over and over again inside the
+hot loop of the trace function, which is not ideal!
+
+In order to avoid that, we intern our keys global to the tracer. This means
+that in the common case where the tracer has already seen the key somewhere we
+don't need to allocate a new one. This can significantly speed up tracing.
+*/
+typedef struct InternEntry {
+    uint64_t key;
+    PyObject *value;
+} InternEntry;
+
+typedef struct InternTable {
+    /* Store the value keyed off zero separately. This allows us to use a key
+       of zero as a not-set indicator. */ 
+    PyObject * zero_value;
+
+    /* The number of elements in our entries array (including absent elements).
+       Always a power of two. */
+    size_t capacity;
+
+    /* The number of entries which have a key set. Always strictly less than
+       capacity. Does not count the zero key. */
+    size_t current_fill;
+
+    /* When the fill exceeds this value, increase the capacity. Always roughly
+       the same fraction of capacity. */
+    size_t max_fill;
+
+    /* Essentially (key, value) tuples where keys are uint64_t and values are
+      *PyObject. Values are owned by the tracer and will have their refcount
+      decremented appropriately on release.*/
+    InternEntry * entries;
+} InternTable;
 
 /* The CTracer type. */
 
@@ -64,6 +105,8 @@ typedef struct CTracer {
     int last_exc_firstlineno;
 
     Stats stats;
+
+    InternTable intern_table;
 } CTracer;
 
 int CTracer_intern_strings(void);

--- a/coverage/ctracer/tracer.h
+++ b/coverage/ctracer/tracer.h
@@ -8,7 +8,6 @@
 #include "structmember.h"
 #include "frameobject.h"
 #include "opcode.h"
-#include <stdint.h>
 
 #include "datastack.h"
 
@@ -25,13 +24,13 @@ that in the common case where the tracer has already seen the key somewhere we
 don't need to allocate a new one. This can significantly speed up tracing.
 */
 typedef struct InternEntry {
-    uint64_t key;
+    PY_LONG_LONG key;
     PyObject *value;
 } InternEntry;
 
 typedef struct InternTable {
     /* Store the value keyed off zero separately. This allows us to use a key
-       of zero as a not-set indicator. */ 
+       of zero as a not-set indicator. */
     PyObject * zero_value;
 
     /* The number of elements in our entries array (including absent elements).
@@ -46,7 +45,7 @@ typedef struct InternTable {
        the same fraction of capacity. */
     size_t max_fill;
 
-    /* Essentially (key, value) tuples where keys are uint64_t and values are
+    /* Essentially (key, value) tuples where keys are PY_LONG_LONG and values are
       *PyObject. Values are owned by the tracer and will have their refcount
       decremented appropriately on release.*/
     InternEntry * entries;
@@ -58,7 +57,7 @@ typedef struct InternTable {
    else.
 */
 typedef struct InternTableObject{
-    PyObject_HEAD;
+    PyObject_HEAD
     InternTable table;
 } InternTableObject;
 

--- a/coverage/ctracer/tracer.h
+++ b/coverage/ctracer/tracer.h
@@ -52,6 +52,16 @@ typedef struct InternTable {
     InternEntry * entries;
 } InternTable;
 
+
+/* We expose a Python interface to the InternTable, but it's purely intended for
+   purposes of testing the InternTable itself and you shouldn't use it for anything
+   else.
+*/
+typedef struct InternTableObject{
+    PyObject_HEAD;
+    InternTable table;
+} InternTableObject;
+
 /* The CTracer type. */
 
 typedef struct CTracer {
@@ -112,5 +122,6 @@ typedef struct CTracer {
 int CTracer_intern_strings(void);
 
 extern PyTypeObject CTracerType;
+extern PyTypeObject InternTableType;
 
 #endif /* _COVERAGE_TRACER_H */

--- a/coverage/ctracer/util.h
+++ b/coverage/ctracer/util.h
@@ -24,6 +24,7 @@
 #define MyText_FromFormat               PyUnicode_FromFormat
 #define MyInt_FromInt(i)                PyLong_FromLong((long)i)
 #define MyInt_AsInt(o)                  (int)PyLong_AsLong(o)
+#define MyInt_AsLongLong(o)             PyLong_AsUnsignedLongLong(o)
 #define MyText_InternFromString(s)      PyUnicode_InternFromString(s)
 
 #define MyType_HEAD_INIT                PyVarObject_HEAD_INIT(NULL, 0)
@@ -37,6 +38,7 @@
 #define MyText_AsString(o)              PyString_AsString(o)
 #define MyText_FromFormat               PyUnicode_FromFormat
 #define MyInt_FromInt(i)                PyInt_FromLong((long)i)
+#define MyInt_AsLongLong(o)             PyInt_AsUnsignedLongLongMask(o)
 #define MyInt_AsInt(o)                  (int)PyInt_AsLong(o)
 #define MyText_InternFromString(s)      PyString_InternFromString(s)
 

--- a/requirements/pytest.pip
+++ b/requirements/pytest.pip
@@ -5,3 +5,4 @@
 pytest==3.2.2
 pytest-xdist==1.20.0
 flaky==3.4.0
+hypothesis==3.30.3

--- a/tests/test_intern_table.py
+++ b/tests/test_intern_table.py
@@ -3,6 +3,7 @@ from tests.coveragetest import CoverageTest
 from hypothesis import given, example
 import hypothesis.strategies as st
 from coverage.tracer import InternTable
+import sys
 
 
 class TestInternTable(CoverageTest):
@@ -27,3 +28,29 @@ class TestInternTable(CoverageTest):
         for i in ls:
             assert table[i] == i
         assert len(table) == len(ls)
+
+    @given(
+        st.lists(st.tuples(st.integers(0, 2**64 - 1)), unique=True).map(
+            lambda ls: list(map(list, ls))
+        ),
+    )
+    def test_maintains_correct_ref_count(self, ls):
+        def refs():
+            return list(map(sys.getrefcount, ls))
+
+        initial_refs = refs()
+        assert refs() == initial_refs
+
+        table = InternTable()
+
+        for i in range(len(ls)):
+            r = initial_refs[i]
+            assert sys.getrefcount(ls[i]) == r + 1
+            x = ls[i][0]
+            table[x] = ls[i]
+            assert sys.getrefcount(ls[i]) == r + 2
+            table[x] = ls[i]
+            assert sys.getrefcount(ls[i]) == r + 2
+
+        del table
+        assert refs() == initial_refs

--- a/tests/test_intern_table.py
+++ b/tests/test_intern_table.py
@@ -1,12 +1,22 @@
+import sys
+
 from tests.coveragetest import CoverageTest
 
 from hypothesis import given, example
 import hypothesis.strategies as st
-from coverage.tracer import InternTable
-import sys
+import pytest
+
+from coverage import env
+
+if env.C_TRACER:
+    from coverage.tracer import InternTable
 
 
+@pytest.mark.skipif(not env.C_TRACER, reason="Only the C tracer has refcounting issues")
 class TestInternTable(CoverageTest):
+
+    run_in_temp_dir = False
+
     @example([0])
     @given(st.lists(st.integers(0, 2 ** 64 - 1), unique=True))
     def test_interns_as_none_by_default(self, ls):

--- a/tests/test_intern_table.py
+++ b/tests/test_intern_table.py
@@ -1,0 +1,29 @@
+from tests.coveragetest import CoverageTest
+
+from hypothesis import given, example
+import hypothesis.strategies as st
+from coverage.tracer import InternTable
+
+
+class TestInternTable(CoverageTest):
+    @example([0])
+    @given(st.lists(st.integers(0, 2 ** 64 - 1), unique=True))
+    def test_interns_as_none_by_default(self, ls):
+        table = InternTable()
+        for i in ls:
+            assert table[i] is None
+
+    @example(list(range(23)))
+    @example([0])
+    @given(st.one_of(
+        st.integers(0, 1000).map(lambda i: list(range(i))),
+        st.lists(st.integers(0, 2 ** 64 - 1), unique=True),
+    ))
+    def test_can_intern_integers_as_themselves(self, ls):
+        table = InternTable()
+        for i in ls:
+            table[i] = i
+            assert table[i] is i
+        for i in ls:
+            assert table[i] == i
+        assert len(table) == len(ls)


### PR DESCRIPTION
This creates a customized C level hash map that maps uint64_t keys to Python objects. This can be used to avoid the slow path of allocating Python tuples (and to a lesser extent Python integers) when tracing lines.

This is likely to help a fair bit for loop-heavy code - in my experiments code which just involved a long-running loop, the overhead for measuring branch coverage dropped from about 50% to about 5% (line coverage was consistently in the 5-10% range, so this brought branch coverage tracking to a comparable level of overhead to line coverage).